### PR TITLE
logging-conform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+.DS_Store

--- a/auth_test.go
+++ b/auth_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/jeroenrinzema/psql-wire/internal/buffer"
 	"github.com/jeroenrinzema/psql-wire/internal/types"
-	"go.uber.org/zap"
+	"github.com/sirupsen/logrus"
 )
 
 func TestDefaultHandleAuth(t *testing.T) {
@@ -20,7 +20,7 @@ func TestDefaultHandleAuth(t *testing.T) {
 	reader := buffer.NewReader(input, buffer.DefaultBufferSize)
 	writer := buffer.NewWriter(sink)
 
-	server := &Server{logger: zap.NewNop()}
+	server := &Server{logger: logrus.StandardLogger()}
 	err := server.handleAuth(ctx, reader, writer)
 	if err != nil {
 		t.Fatal(err)
@@ -76,7 +76,7 @@ func TestClearTextPassword(t *testing.T) {
 	reader := buffer.NewReader(input, buffer.DefaultBufferSize)
 	writer := buffer.NewWriter(sink)
 
-	server := &Server{logger: zap.NewNop(), Auth: ClearTextPassword(validate)}
+	server := &Server{logger: logrus.StandardLogger(), Auth: ClearTextPassword(validate)}
 	err := server.handleAuth(ctx, reader, writer)
 	if err != nil {
 		t.Error("unexpected error:", err)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c
 	github.com/lib/pq v1.10.4
+	github.com/sirupsen/logrus v1.4.2
 	go.uber.org/zap v1.19.1
 	golang.org/x/tools v0.1.5
 )

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,7 @@ github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9Nz
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/options.go
+++ b/options.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 
 	"github.com/jeroenrinzema/psql-wire/pkg/sqlbackend"
-	"go.uber.org/zap"
+	"github.com/sirupsen/logrus"
 )
 
 // OptionFn options pattern used to define and set options for the given
@@ -83,7 +83,7 @@ func GlobalParameters(params Parameters) OptionFn {
 }
 
 // Logger sets the given zap logger as the default logger for the given server.
-func Logger(logger *zap.Logger) OptionFn {
+func Logger(logger *logrus.Logger) OptionFn {
 	return func(srv *Server) {
 		srv.logger = logger
 	}

--- a/wire.go
+++ b/wire.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jeroenrinzema/psql-wire/internal/buffer"
 	"github.com/jeroenrinzema/psql-wire/internal/types"
 	"github.com/jeroenrinzema/psql-wire/pkg/sqlbackend"
+	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 )
 
@@ -29,7 +30,7 @@ func ListenAndServe(address string, handler SimpleQueryFn) error {
 // NewServer constructs a new Postgres server using the given address and server options.
 func NewServer(options ...OptionFn) (*Server, error) {
 	srv := &Server{
-		logger: zap.NewNop(),
+		logger: logrus.StandardLogger(),
 		closer: make(chan struct{}),
 	}
 
@@ -43,7 +44,7 @@ func NewServer(options ...OptionFn) (*Server, error) {
 // Server contains options for listening to an address.
 type Server struct {
 	wg              sync.WaitGroup
-	logger          *zap.Logger
+	logger          *logrus.Logger
 	Auth            AuthStrategy
 	BufferedMsgSize int
 	Parameters      Parameters


### PR DESCRIPTION
## Summary:

- Replace `zap` logger with `logrus`.
- Same logger transferrable from `stackql`.