### PR TITLE
server-publish-notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import (
 func main() {
 	wire.ListenAndServe("127.0.0.1:5432", func(ctx context.Context, query string, writer wire.DataWriter) error {
 		fmt.Println(query)
-		return writer.Complete("OK")
+		return writer.Complete("", "OK")
 	})
 }
 ```

--- a/command.go
+++ b/command.go
@@ -170,14 +170,15 @@ func (srv *Server) handleSimpleQuery(ctx context.Context, cn SQLConnection) erro
 			var headersWritten bool
 			for {
 				if rdr == nil {
-					dw.Complete("OK")
+					dw.Complete("", "OK")
 					return nil
 				}
 				res, err := rdr.Read()
 				if err != nil {
 					if errors.Is(err, io.EOF) {
+						notices := cn.GetDebugStr()
 						if res == nil {
-							dw.Complete("OK")
+							dw.Complete(notices, "OK")
 							return nil
 						}
 						if !headersWritten {
@@ -185,7 +186,8 @@ func (srv *Server) handleSimpleQuery(ctx context.Context, cn SQLConnection) erro
 							srv.writeSQLResultHeader(ctx, res, dw)
 						}
 						srv.writeSQLResultRows(ctx, res, dw)
-						dw.Complete("OK")
+						// TODO: add debug messages, configurably
+						dw.Complete(notices, "OK")
 						return nil
 					}
 					return ErrorCode(cn, err)

--- a/connection.go
+++ b/connection.go
@@ -22,6 +22,7 @@ type SQLConnection interface {
 	ID() uint64
 	HandleSimpleQuery(context.Context, string) (sqldata.ISQLResultStream, error)
 	SplitCompoundQuery(string) ([]string, error)
+	GetDebugStr() string
 	HasSQLBackend() bool
 }
 
@@ -51,6 +52,13 @@ func NewSQLConnection(
 
 func (c *simpleSqlConnection) HasSQLBackend() bool {
 	return c.sqlBackend != nil
+}
+
+func (c *simpleSqlConnection) GetDebugStr() string {
+	if c.sqlBackend != nil {
+		return c.sqlBackend.GetDebugStr()
+	}
+	return ""
 }
 
 func (c *simpleSqlConnection) HandleSimpleQuery(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -43,5 +43,5 @@ func handle(ctx context.Context, query string, writer wire.DataWriter) error {
 	writer.Define(table)
 	writer.Row([]interface{}{"John", true, 29})
 	writer.Row([]interface{}{"Marry", false, 21})
-	return writer.Complete("OK")
+	return writer.Complete("", "OK")
 }

--- a/examples/tls/main.go
+++ b/examples/tls/main.go
@@ -34,5 +34,5 @@ func run() error {
 }
 
 func handle(ctx context.Context, query string, writer wire.DataWriter) error {
-	return writer.Complete("OK")
+	return writer.Complete("", "OK")
 }

--- a/options.go
+++ b/options.go
@@ -27,6 +27,18 @@ func SQLBackendFactory(sb sqlbackend.SQLBackendFactory) OptionFn {
 	}
 }
 
+func IsCaptureDebug(isCaptureDebug bool) OptionFn {
+	return func(srv *Server) {
+		srv.isCaptureDebug = isCaptureDebug
+	}
+}
+
+func SundryConfig(sc map[string]interface{}) OptionFn {
+	return func(srv *Server) {
+		srv.sundryConfig = sc
+	}
+}
+
 // CloseConn sets the close connection handle inside the given server instance.
 func CloseConn(fn CloseFn) OptionFn {
 	return func(srv *Server) {

--- a/pkg/sqlbackend/pgsqlbackend.go
+++ b/pkg/sqlbackend/pgsqlbackend.go
@@ -15,17 +15,22 @@ type SQLBackendFactory interface {
 type ISQLBackend interface {
 	HandleSimpleQuery(context.Context, string) (sqldata.ISQLResultStream, error)
 	SplitCompoundQuery(string) ([]string, error)
+	GetDebugStr() string
 }
 
 type SimpleSQLBackend struct {
 	simpleCallback QueryCallback
 }
 
-func (sb *SimpleSQLBackend) CloneSQLBackend() ISQLBackend {
-	return &SimpleSQLBackend{
-		simpleCallback: sb.simpleCallback,
-	}
+func (sb *SimpleSQLBackend) GetDebugStr() string {
+	return ""
 }
+
+// func (sb *SimpleSQLBackend) CloneSQLBackend() ISQLBackend {
+// 	return &SimpleSQLBackend{
+// 		simpleCallback: sb.simpleCallback,
+// 	}
+// }
 
 func (sb *SimpleSQLBackend) HandleSimpleQuery(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
 	return sb.simpleCallback(ctx, query)
@@ -51,6 +56,7 @@ func (sb *SimpleSQLBackend) SplitCompoundQuery(s string) ([]string, error) {
 	return append(res, s[beg:]), nil
 }
 
+// TODO: debug message handling
 func NewSimpleSQLBackend(simpleCallback QueryCallback) ISQLBackend {
 	return &SimpleSQLBackend{
 		simpleCallback: simpleCallback,

--- a/wire.go
+++ b/wire.go
@@ -31,8 +31,9 @@ func ListenAndServe(address string, handler SimpleQueryFn) error {
 // NewServer constructs a new Postgres server using the given address and server options.
 func NewServer(options ...OptionFn) (*Server, error) {
 	srv := &Server{
-		logger: logrus.StandardLogger(),
-		closer: make(chan struct{}),
+		logger:       logrus.StandardLogger(),
+		closer:       make(chan struct{}),
+		sundryConfig: make(map[string]interface{}),
 	}
 
 	for _, option := range options {
@@ -56,7 +57,9 @@ type Server struct {
 	SQLBackendFactory sqlbackend.SQLBackendFactory
 	CloseConn         CloseFn
 	TerminateConn     CloseFn
+	isCaptureDebug    bool
 	closer            chan struct{}
+	sundryConfig      map[string]interface{}
 }
 
 func (srv *Server) CreateSQLBackend() (sqlbackend.ISQLBackend, error) {

--- a/wire_test.go
+++ b/wire_test.go
@@ -40,7 +40,7 @@ func TestClientConnect(t *testing.T) {
 	t.Parallel()
 
 	pong := func(ctx context.Context, query string, writer DataWriter) error {
-		return writer.Complete("OK")
+		return writer.Complete("", "OK")
 	}
 
 	server, err := NewServer(SimpleQuery(pong))
@@ -133,7 +133,7 @@ func TestServerWritingResult(t *testing.T) {
 
 		writer.Row([]interface{}{"John", true, 28})   //nolint:errcheck
 		writer.Row([]interface{}{"Marry", false, 21}) //nolint:errcheck
-		return writer.Complete("OK")
+		return writer.Complete("", "OK")
 	}
 
 	server, err := NewServer(SimpleQuery(handler))


### PR DESCRIPTION
## Summary

- Publish notice messages over wire protocol.
- Opt-in.
- Emulating the actual `postgres` backend, per [send_message_to_frontend()](https://github.com/postgres/postgres/blob/4694aedf63bf5b5d91f766cb6d6d6d14a9e4434b/src/backend/utils/error/elog.c#L3516)