### PR TITLE
Fix: consumeCommands - return if conn is closed.

### DIFF
--- a/command.go
+++ b/command.go
@@ -69,6 +69,11 @@ func (srv *Server) consumeCommands(ctx context.Context, conn SQLConnection) (err
 		if err != nil {
 			return err
 		}
+
+		// NOTE(Prasad): If conn is closed after handleCommand return.
+		if t == types.ClientClose || t == types.ClientTerminate {
+			return nil
+		}
 	}
 }
 


### PR DESCRIPTION
When client connection is closed stop reading query further.