### PR TITLE
extended-query-support

### DIFF
--- a/command.go
+++ b/command.go
@@ -23,27 +23,39 @@ func NewErrUnimplementedMessageType(t types.ClientMessage) error {
 	return psqlerr.WithSeverity(psqlerr.WithCode(err, codes.ConnectionDoesNotExist), psqlerr.LevelFatal)
 }
 
+// errExtendedQueryError is a sentinel error returned by extended query handlers
+// when they have already sent an ErrorResponse to the client. The command loop
+// uses this to enter error state: all subsequent messages are discarded until
+// Sync, which sends ReadyForQuery with a failed-transaction status.
+var errExtendedQueryError = errors.New("extended query error")
+
 type SimpleQueryFn func(ctx context.Context, query string, writer DataWriter) error
 
 type CloseFn func(ctx context.Context) error
 
-// consumeCommands consumes incoming commands send over the Postgres wire connection.
+// consumeCommands consumes incoming commands sent over the Postgres wire connection.
 // Commands consumed from the connection are returned through a go channel.
 // Responses for the given message type are written back to the client.
-// This method keeps consuming messages until the client issues a close message
+// This method keeps consuming messages until the client issues a terminate message
 // or the connection is terminated.
+//
+// ReadyForQuery is sent once initially, then only after SimpleQuery completion
+// and Sync messages (per the PostgreSQL extended query protocol).
 func (srv *Server) consumeCommands(ctx context.Context, conn SQLConnection) (err error) {
 	srv.logger.Debug("ready for query... starting to consume commands")
 
-	// TODO(Jeroen): include a indentification value inside the context that
-	// could be used to identify connections at a later stage.
+	// Send initial ReadyForQuery
+	err = readyForQuery(conn, types.ServerIdle)
+	if err != nil {
+		return err
+	}
+
+	// inErrorState tracks whether an extended query handler has failed.
+	// Per the PostgreSQL protocol, after an error in extended query mode,
+	// all subsequent messages are discarded until a Sync message is received.
+	inErrorState := false
 
 	for {
-		err = readyForQuery(conn, types.ServerIdle)
-		if err != nil {
-			return err
-		}
-
 		t, length, err := conn.ReadTypedMsg()
 		if err == io.EOF {
 			return nil
@@ -52,6 +64,12 @@ func (srv *Server) consumeCommands(ctx context.Context, conn SQLConnection) (err
 		// NOTE(Jeroen): we could recover from this scenario
 		if errors.Is(err, buffer.ErrMessageSizeExceeded) {
 			err = srv.handleMessageSizeExceeded(conn, conn, err)
+			if err != nil {
+				return err
+			}
+
+			// Send ReadyForQuery after error recovery
+			err = readyForQuery(conn, types.ServerIdle)
 			if err != nil {
 				return err
 			}
@@ -65,7 +83,32 @@ func (srv *Server) consumeCommands(ctx context.Context, conn SQLConnection) (err
 			return err
 		}
 
+		// When in error state, discard all messages except Sync and Terminate.
+		// Sync resets the error state; Terminate always closes the connection.
+		if inErrorState {
+			switch t {
+			case types.ClientSync:
+				inErrorState = false
+				err = readyForQuery(conn, types.ServerTransactionFailed)
+				if err != nil {
+					return err
+				}
+			case types.ClientTerminate:
+				err = srv.handleCommand(ctx, conn, t)
+				if err != nil {
+					return err
+				}
+			default:
+				srv.logger.Debug("discarding message in error state", zap.String("type", string(t)))
+			}
+			continue
+		}
+
 		err = srv.handleCommand(ctx, conn, t)
+		if errors.Is(err, errExtendedQueryError) {
+			inErrorState = true
+			continue
+		}
 		if err != nil {
 			return err
 		}
@@ -97,28 +140,31 @@ func (srv *Server) handleMessageSizeExceeded(reader buffer.Reader, writer buffer
 
 // handleCommand handles the given client message. A client message includes a
 // message type and reader buffer containing the actual message. The type
-// indecates a action executed by the client.
+// indicates an action executed by the client.
+//
+// For the extended query protocol, ReadyForQuery is NOT sent after each message.
+// It is only sent by handleSync (after Sync) and handleSimpleQuery (after SimpleQuery).
 func (srv *Server) handleCommand(ctx context.Context, conn SQLConnection, t types.ClientMessage) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	switch t {
-	case types.ClientSync:
-		// TODO(Jeroen): client sync received
-		return srv.completeSuccess(ctx, conn)
 	case types.ClientSimpleQuery:
-		// TODO: make this a function of connection
 		return srv.handleSimpleQuery(ctx, conn)
-	case types.ClientExecute:
-		return srv.completeSuccess(ctx, conn)
 	case types.ClientParse:
-		return srv.completeSuccess(ctx, conn)
-	case types.ClientDescribe:
-		return srv.completeSuccess(ctx, conn)
+		return srv.handleParse(ctx, conn)
 	case types.ClientBind:
-		return srv.completeSuccess(ctx, conn)
+		return srv.handleBind(ctx, conn)
+	case types.ClientDescribe:
+		return srv.handleDescribe(ctx, conn)
+	case types.ClientExecute:
+		return srv.handleExecute(ctx, conn)
+	case types.ClientSync:
+		return srv.handleSync(ctx, conn)
 	case types.ClientFlush:
-		return srv.completeSuccess(ctx, conn)
+		return srv.handleFlush(ctx, conn)
+	case types.ClientClose:
+		return srv.handleClose(ctx, conn)
 	case types.ClientCopyData, types.ClientCopyDone, types.ClientCopyFail:
 		// We're supposed to ignore these messages, per the protocol spec. This
 		// state will happen when an error occurs on the server-side during a copy
@@ -126,14 +172,12 @@ func (srv *Server) handleCommand(ctx context.Context, conn SQLConnection, t type
 		// the client, and must then ignore further copy messages. See:
 		// https://github.com/postgres/postgres/blob/6e1dd2773eb60a6ab87b27b8d9391b756e904ac3/src/backend/tcop/postgres.c#L4295
 		break
-	case types.ClientClose:
+	case types.ClientTerminate:
 		err = srv.handleConnClose(ctx)
 		if err != nil {
 			return err
 		}
 
-		return conn.Close()
-	case types.ClientTerminate:
 		err = srv.handleConnTerminate(ctx)
 		if err != nil {
 			return err
@@ -147,18 +191,11 @@ func (srv *Server) handleCommand(ctx context.Context, conn SQLConnection, t type
 	return nil
 }
 
-func (srv *Server) completeSuccess(ctx context.Context, cn SQLConnection) error {
-	dw := &dataWriter{
-		ctx:    ctx,
-		client: cn,
-	}
-	dw.Complete("", "OK")
-	return nil
-}
 
 func (srv *Server) handleSimpleQuery(ctx context.Context, cn SQLConnection) error {
 	if srv.SimpleQuery == nil && srv.SQLBackendFactory == nil {
-		return ErrorCode(cn, NewErrUnimplementedMessageType(types.ClientSimpleQuery))
+		ErrorCode(cn, NewErrUnimplementedMessageType(types.ClientSimpleQuery))
+		return readyForQuery(cn, types.ServerIdle)
 	}
 
 	query, err := cn.GetString()
@@ -177,14 +214,15 @@ func (srv *Server) handleSimpleQuery(ctx context.Context, cn SQLConnection) erro
 			if q == "" {
 				if i == len(qArr)-1 {
 					// trailing semicolon, ignore
-					srv.completeSuccess(ctx, cn)
-					return nil
+					commandComplete(cn, "OK")
+					return readyForQuery(cn, types.ServerIdle)
 				}
 				continue
 			}
 			rdr, err := cn.HandleSimpleQuery(ctx, q)
 			if err != nil {
-				return ErrorCode(cn, err)
+				ErrorCode(cn, err)
+				return readyForQuery(cn, types.ServerIdle)
 			}
 			dw := &dataWriter{
 				ctx:    ctx,
@@ -194,7 +232,7 @@ func (srv *Server) handleSimpleQuery(ctx context.Context, cn SQLConnection) erro
 			for {
 				if rdr == nil {
 					dw.Complete("", "OK")
-					return nil
+					return readyForQuery(cn, types.ServerIdle)
 				}
 				res, err := rdr.Read()
 				if err != nil {
@@ -202,7 +240,7 @@ func (srv *Server) handleSimpleQuery(ctx context.Context, cn SQLConnection) erro
 						notices := cn.GetDebugStr()
 						if res == nil {
 							dw.Complete(notices, "OK")
-							return nil
+							return readyForQuery(cn, types.ServerIdle)
 						}
 						if !headersWritten {
 							headersWritten = true
@@ -211,9 +249,10 @@ func (srv *Server) handleSimpleQuery(ctx context.Context, cn SQLConnection) erro
 						srv.writeSQLResultRows(ctx, res, dw)
 						// TODO: add debug messages, configurably
 						dw.Complete(notices, "OK")
-						return nil
+						return readyForQuery(cn, types.ServerIdle)
 					}
-					return ErrorCode(cn, err)
+					ErrorCode(cn, err)
+					return readyForQuery(cn, types.ServerIdle)
 				}
 				if !headersWritten {
 					headersWritten = true
@@ -230,10 +269,11 @@ func (srv *Server) handleSimpleQuery(ctx context.Context, cn SQLConnection) erro
 	})
 
 	if err != nil {
-		return ErrorCode(cn, err)
+		ErrorCode(cn, err)
+		return readyForQuery(cn, types.ServerIdle)
 	}
 
-	return nil
+	return readyForQuery(cn, types.ServerIdle)
 }
 
 func (srv *Server) writeSQLResultRows(ctx context.Context, res sqldata.ISQLResult, writer DataWriter) error {

--- a/connection.go
+++ b/connection.go
@@ -24,14 +24,20 @@ type SQLConnection interface {
 	SplitCompoundQuery(string) ([]string, error)
 	GetDebugStr() string
 	HasSQLBackend() bool
+	ExtendedBackend() sqlbackend.IExtendedQueryBackend
+	Statements() PreparedStatementCache
+	Portals() PortalCache
 }
 
 type simpleSqlConnection struct {
-	id         uint64
-	netConn    net.Conn
-	reader     buffer.Reader
-	writer     buffer.Writer
-	sqlBackend sqlbackend.ISQLBackend
+	id              uint64
+	netConn         net.Conn
+	reader          buffer.Reader
+	writer          buffer.Writer
+	sqlBackend      sqlbackend.ISQLBackend
+	extendedBackend sqlbackend.IExtendedQueryBackend
+	statements      PreparedStatementCache
+	portals         PortalCache
 }
 
 func NewSQLConnection(
@@ -41,17 +47,38 @@ func NewSQLConnection(
 	writer buffer.Writer,
 	sqlBackend sqlbackend.ISQLBackend,
 ) SQLConnection {
+	var extBackend sqlbackend.IExtendedQueryBackend
+	if eb, ok := sqlBackend.(sqlbackend.IExtendedQueryBackend); ok {
+		extBackend = eb
+	} else if sqlBackend != nil {
+		extBackend = sqlbackend.NewDefaultExtendedQueryBackend(sqlBackend)
+	}
 	return &simpleSqlConnection{
-		id:         id,
-		netConn:    netConn,
-		reader:     reader,
-		writer:     writer,
-		sqlBackend: sqlBackend,
+		id:              id,
+		netConn:         netConn,
+		reader:          reader,
+		writer:          writer,
+		sqlBackend:      sqlBackend,
+		extendedBackend: extBackend,
+		statements:      NewPreparedStatementCache(),
+		portals:         NewPortalCache(),
 	}
 }
 
 func (c *simpleSqlConnection) HasSQLBackend() bool {
 	return c.sqlBackend != nil
+}
+
+func (c *simpleSqlConnection) ExtendedBackend() sqlbackend.IExtendedQueryBackend {
+	return c.extendedBackend
+}
+
+func (c *simpleSqlConnection) Statements() PreparedStatementCache {
+	return c.statements
+}
+
+func (c *simpleSqlConnection) Portals() PortalCache {
+	return c.portals
 }
 
 func (c *simpleSqlConnection) GetDebugStr() string {

--- a/docs/aot_metadata.md
+++ b/docs/aot_metadata.md
@@ -1,0 +1,31 @@
+
+# AOT metadata
+
+The postgres wire protocol supports many ahead of time (AOT) metadata exchanges, eg:
+
+- Columns and types returned by a query.
+- Other aspects of extended querying per [the postgres documentation](https://www.postgresql.org/docs/16/protocol-overview.html#PROTOCOL-QUERY-CONCEPTS).
+
+
+These are required for prepared statement execution and are used liberally by client libraries in various language runtimes.
+
+
+## Important Aspects
+
+### Support for full wire protocol messages
+
+The main focus is support for extended queries; the theory being that this results in seamless consumption of stackql by myriad client libraries.
+
+That said, there is little reason not to fully support all messages [per the docs](https://www.postgresql.org/docs/16/protocol-message-formats.html).
+
+The SQL backend interface needs some breadth in order to achieve this.  We support a blended and opt in implementation that leverages a combination of simple query only implementation plus method stubs for extended.  A word of caution, the prior logic is integral to correct function of the simple query function and so ideally changes should not break existing clients.  The regression test suite is visible in [the `stackql` core repository](https://github.com/stackql/stackql).
+
+### Full wire protocol support with stackql
+
+The `psql-wire` library exposes an `IExtendedQueryBackend` interface that stackql can implement to participate in the extended query protocol.  A `DefaultExtendedQueryBackend` exists that delegates execution to the simple query path, so basic compatibility comes for free.  Richer support involves the following areas within stackql:
+
+- **Parameter type resolution**: `HandleParse` receives parameter OIDs (which may be zero/unspecified).  stackql resolves these against its own type system and returns concrete OIDs so that clients can format bind values correctly.
+- **Result column metadata**: `HandleDescribeStatement` and `HandleDescribePortal` return column names, types, and widths.  stackql derives this from its query planner or schema metadata so that clients like pgx can allocate typed scan targets before any rows arrive.
+- **Parameterised execution**: `HandleExecute` receives the bound parameter values alongside the original query.  stackql substitutes these into its execution pipeline, replacing the simple string-only path.
+- **Statement and portal lifecycle**: `HandleCloseStatement` and `HandleClosePortal` allow stackql to release any cached plans or intermediate state associated with a named prepared statement or portal.
+- **Bind-time validation**: `HandleBind` gives stackql an opportunity to validate parameter formats and values before execution, enabling early error reporting within the extended query error-recovery model (errors before `Sync` do not tear down the connection).

--- a/docs/stackql_backend_migration.md
+++ b/docs/stackql_backend_migration.md
@@ -1,0 +1,217 @@
+# Migrating a stackql backend to extended query support
+
+This document describes how to add extended query protocol support to a stackql `ISQLBackend` implementation, replacing the default stubs provided by `psql-wire`.
+
+## Background
+
+The `psql-wire` library auto-detects whether an `ISQLBackend` also implements `IExtendedQueryBackend` via a type assertion in `connection.go`:
+
+```go
+if eb, ok := sqlBackend.(sqlbackend.IExtendedQueryBackend); ok {
+    extBackend = eb
+} else if sqlBackend != nil {
+    extBackend = sqlbackend.NewDefaultExtendedQueryBackend(sqlBackend)
+}
+```
+
+If the backend does not implement `IExtendedQueryBackend`, a `DefaultExtendedQueryBackend` wraps it. This default delegates `HandleExecute` to `HandleSimpleQuery` and stubs out everything else. Client libraries like pgx can connect and run unparameterised queries through this path.
+
+No factory or wiring changes are needed to opt in. Adding the methods to the existing struct is sufficient.
+
+## The IExtendedQueryBackend interface
+
+```go
+type IExtendedQueryBackend interface {
+    HandleParse(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, error)
+    HandleBind(ctx context.Context, portalName string, stmtName string, paramFormats []int16, paramValues [][]byte, resultFormats []int16) error
+    HandleDescribeStatement(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, []sqldata.ISQLColumn, error)
+    HandleDescribePortal(ctx context.Context, portalName string, stmtName string, query string, paramOIDs []uint32) ([]sqldata.ISQLColumn, error)
+    HandleExecute(ctx context.Context, portalName string, stmtName string, query string, paramFormats []int16, paramValues [][]byte, resultFormats []int16, maxRows int32) (sqldata.ISQLResultStream, error)
+    HandleCloseStatement(ctx context.Context, stmtName string) error
+    HandleClosePortal(ctx context.Context, portalName string) error
+}
+```
+
+## Migration steps
+
+### Step 1: Add no-op stubs to the existing backend
+
+Locate the struct in stackql that implements `ISQLBackend` (the one with `HandleSimpleQuery`, `SplitCompoundQuery`, and `GetDebugStr`). Add the seven methods below. These are direct copies of the `DefaultExtendedQueryBackend` behaviour, so robot tests should produce identical results.
+
+```go
+func (sb *YourBackend) HandleParse(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, error) {
+    return paramOIDs, nil
+}
+
+func (sb *YourBackend) HandleBind(ctx context.Context, portalName string, stmtName string, paramFormats []int16, paramValues [][]byte, resultFormats []int16) error {
+    return nil
+}
+
+func (sb *YourBackend) HandleDescribeStatement(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, []sqldata.ISQLColumn, error) {
+    return paramOIDs, nil, nil
+}
+
+func (sb *YourBackend) HandleDescribePortal(ctx context.Context, portalName string, stmtName string, query string, paramOIDs []uint32) ([]sqldata.ISQLColumn, error) {
+    return nil, nil
+}
+
+func (sb *YourBackend) HandleExecute(ctx context.Context, portalName string, stmtName string, query string, paramFormats []int16, paramValues [][]byte, resultFormats []int16, maxRows int32) (sqldata.ISQLResultStream, error) {
+    return sb.HandleSimpleQuery(ctx, query)
+}
+
+func (sb *YourBackend) HandleCloseStatement(ctx context.Context, stmtName string) error {
+    return nil
+}
+
+func (sb *YourBackend) HandleClosePortal(ctx context.Context, portalName string) error {
+    return nil
+}
+```
+
+**Verification**: run the full robot test suite. Behaviour should be unchanged.
+
+### Step 2: Add a compile-time interface check
+
+Near the top of the file, add:
+
+```go
+var _ sqlbackend.IExtendedQueryBackend = (*YourBackend)(nil)
+```
+
+This ensures the compiler catches missing methods if the interface changes.
+
+### Step 3: Implement HandleExecute with parameter substitution
+
+`HandleExecute` receives the query string and bound parameter values. The parameters arrive as:
+
+- `paramFormats []int16` — one entry per parameter: `0` = text, `1` = binary. May be empty (all text) or length 1 (applies to all).
+- `paramValues [][]byte` — raw bytes for each parameter. `nil` entry = SQL NULL.
+- `resultFormats []int16` — requested result column formats (currently safe to ignore; the wire library encodes as text).
+
+#### Option A: String interpolation (simplest)
+
+Replace positional parameters (`$1`, `$2`, ...) with their text values, applying appropriate quoting, then delegate to `HandleSimpleQuery`:
+
+```go
+func (sb *YourBackend) HandleExecute(ctx context.Context, portalName string, stmtName string, query string, paramFormats []int16, paramValues [][]byte, resultFormats []int16, maxRows int32) (sqldata.ISQLResultStream, error) {
+    resolved := substituteParams(query, paramFormats, paramValues)
+    return sb.HandleSimpleQuery(ctx, resolved)
+}
+```
+
+Where `substituteParams` replaces `$N` tokens with the corresponding text value. Rules:
+
+- `paramValues[i] == nil` → substitute `NULL` (no quotes).
+- Otherwise use the text representation from `paramValues[i]`. Quote string values with single quotes and escape embedded single quotes by doubling them (`'` → `''`).
+- If `paramFormats` is empty or has length 1, treat all parameters as that format (usually 0 = text).
+
+#### Option B: Native parameterisation
+
+If the stackql execution engine supports parameterised queries, pass the values through directly. This avoids quoting issues and is more correct long-term.
+
+**Verification**: write a test that connects with pgx, runs a parameterised query, and checks the results:
+
+```go
+rows, err := conn.Query(ctx, "SELECT $1::text, $2::int", "hello", 42)
+```
+
+### Step 4: Implement HandleDescribeStatement
+
+Client libraries call Describe after Parse to learn the result column types before any rows arrive. This allows typed scanning (e.g., pgx allocates `int32` vs `string` targets).
+
+Return parameter OIDs and result column metadata:
+
+```go
+func (sb *YourBackend) HandleDescribeStatement(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, []sqldata.ISQLColumn, error) {
+    columns, err := sb.planQuery(query) // derive columns from query planner / schema
+    if err != nil {
+        return nil, nil, err
+    }
+    return paramOIDs, columns, nil
+}
+```
+
+Each `ISQLColumn` requires:
+- `GetName()` — column name
+- `GetObjectID()` — PostgreSQL type OID (e.g., `25` for text, `23` for int4, `16` for bool)
+- `GetWidth()` — column width in bytes (use `-1` if variable)
+- `GetTableId()`, `GetAttrNum()` — can be `0` if not applicable
+- `GetTypeModifier()` — usually `-1`
+- `GetFormat()` — `"text"` for text format
+
+If the query planner cannot derive columns (e.g., for DDL), return `nil` columns — the wire library sends `NoData`, which is valid.
+
+**Verification**: use pgx to prepare a statement and check that `FieldDescriptions()` returns the expected column metadata.
+
+### Step 5: Implement HandleDescribePortal
+
+Similar to `HandleDescribeStatement`, but for a bound portal. The portal already has its parameters bound, so column metadata may be more precise. In many cases this can delegate to the same logic:
+
+```go
+func (sb *YourBackend) HandleDescribePortal(ctx context.Context, portalName string, stmtName string, query string, paramOIDs []uint32) ([]sqldata.ISQLColumn, error) {
+    _, columns, err := sb.HandleDescribeStatement(ctx, stmtName, query, paramOIDs)
+    return columns, err
+}
+```
+
+### Step 6: Implement HandleParse with type resolution
+
+If stackql can resolve unspecified parameter types (OID = 0) from the query, do so in `HandleParse`. Otherwise, the current pass-through is fine — clients that send OID 0 will format parameters as text, which works with string interpolation.
+
+```go
+func (sb *YourBackend) HandleParse(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, error) {
+    resolved, err := sb.resolveParamTypes(query, paramOIDs)
+    if err != nil {
+        return nil, err
+    }
+    return resolved, nil
+}
+```
+
+### Step 7: Implement HandleBind with validation
+
+If stackql can validate parameter values at bind time, do so here. Errors returned from `HandleBind` are reported to the client before execution, and the connection enters error recovery mode (messages discarded until Sync). This gives the client a chance to re-bind with corrected values.
+
+### Step 8: Implement HandleCloseStatement / HandleClosePortal
+
+If stackql caches query plans or intermediate state, release them here. If not, the no-ops from step 1 are correct.
+
+## Error recovery
+
+The wire library handles error recovery automatically. If any `IExtendedQueryBackend` method returns an error:
+
+1. An `ErrorResponse` is sent to the client.
+2. All subsequent messages are discarded until the client sends `Sync`.
+3. `Sync` sends `ReadyForQuery('E')` (failed transaction status).
+4. The client can then retry or issue new commands.
+
+Backend methods should return errors freely. They do not need to manage connection state.
+
+## Testing strategy
+
+Each step should be verified independently:
+
+1. **Step 1 (stubs)**: full robot test suite — no regressions.
+2. **Step 3 (execute)**: pgx test with parameterised `SELECT $1::text` — returns correct value.
+3. **Step 4 (describe)**: pgx `Prepare` + check `FieldDescriptions()` — column names and OIDs match.
+4. **Step 5 (describe portal)**: pgx query with `QueryRow` — typed scan works without explicit type hints.
+5. **Step 6 (parse)**: pgx query with untyped parameters — server resolves types, client formats correctly.
+
+For each step, a pgx integration test is the most realistic validation since pgx exercises the full Parse → Describe → Bind → Execute → Sync pipeline.
+
+## Common OIDs for reference
+
+| Type    | OID  | Go type       |
+|---------|------|---------------|
+| bool    | 16   | bool          |
+| int2    | 21   | int16         |
+| int4    | 23   | int32         |
+| int8    | 20   | int64         |
+| float4  | 700  | float32       |
+| float8  | 701  | float64       |
+| text    | 25   | string        |
+| varchar | 1043 | string        |
+| json    | 114  | string/[]byte |
+| jsonb   | 3802 | string/[]byte |
+
+These are defined in `github.com/lib/pq/oid` as `oid.T_bool`, `oid.T_int4`, etc.

--- a/extended_query.go
+++ b/extended_query.go
@@ -1,0 +1,432 @@
+package wire
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/lib/pq/oid"
+	"github.com/stackql/psql-wire/internal/buffer"
+	"github.com/stackql/psql-wire/internal/types"
+	"github.com/stackql/psql-wire/pkg/sqldata"
+	"go.uber.org/zap"
+)
+
+// handleParse handles the Parse message ('P') of the extended query protocol.
+// It parses the SQL statement and caches it as a prepared statement.
+func (srv *Server) handleParse(ctx context.Context, conn SQLConnection) error {
+	stmtName, err := conn.GetString()
+	if err != nil {
+		return err
+	}
+
+	query, err := conn.GetString()
+	if err != nil {
+		return err
+	}
+
+	numParams, err := conn.GetUint16()
+	if err != nil {
+		return err
+	}
+
+	paramOIDs := make([]uint32, numParams)
+	for i := 0; i < int(numParams); i++ {
+		oidVal, err := conn.GetUint32()
+		if err != nil {
+			return err
+		}
+		paramOIDs[i] = oidVal
+	}
+
+	srv.logger.Debug("parse",
+		zap.String("statement", stmtName),
+		zap.String("query", query),
+		zap.Int("params", int(numParams)),
+	)
+
+	extBackend := conn.ExtendedBackend()
+	if extBackend != nil {
+		resolvedOIDs, err := extBackend.HandleParse(ctx, stmtName, query, paramOIDs)
+		if err != nil {
+			return extendedError(conn, err)
+		}
+		paramOIDs = resolvedOIDs
+	}
+
+	conn.Statements()[stmtName] = &PreparedStatement{
+		Name:      stmtName,
+		Query:     query,
+		ParamOIDs: paramOIDs,
+	}
+
+	return writeParseComplete(conn)
+}
+
+// handleBind handles the Bind message ('B') of the extended query protocol.
+// It binds parameter values to a prepared statement, creating a portal.
+func (srv *Server) handleBind(ctx context.Context, conn SQLConnection) error {
+	portalName, err := conn.GetString()
+	if err != nil {
+		return err
+	}
+
+	stmtName, err := conn.GetString()
+	if err != nil {
+		return err
+	}
+
+	stmt, ok := conn.Statements()[stmtName]
+	if !ok {
+		return extendedError(conn, errors.New("prepared statement does not exist: "+stmtName))
+	}
+
+	// Read parameter format codes
+	numParamFormats, err := conn.GetUint16()
+	if err != nil {
+		return err
+	}
+	paramFormats := make([]int16, numParamFormats)
+	for i := 0; i < int(numParamFormats); i++ {
+		v, err := conn.GetUint16()
+		if err != nil {
+			return err
+		}
+		paramFormats[i] = int16(v)
+	}
+
+	// Read parameter values
+	numParams, err := conn.GetUint16()
+	if err != nil {
+		return err
+	}
+	paramValues := make([][]byte, numParams)
+	for i := 0; i < int(numParams); i++ {
+		length, err := conn.GetUint32()
+		if err != nil {
+			return err
+		}
+		// -1 indicates NULL
+		if int32(length) == -1 {
+			paramValues[i] = nil
+		} else {
+			val, err := conn.GetBytes(int(length))
+			if err != nil {
+				return err
+			}
+			paramValues[i] = val
+		}
+	}
+
+	// Read result format codes
+	numResultFormats, err := conn.GetUint16()
+	if err != nil {
+		return err
+	}
+	resultFormats := make([]int16, numResultFormats)
+	for i := 0; i < int(numResultFormats); i++ {
+		v, err := conn.GetUint16()
+		if err != nil {
+			return err
+		}
+		resultFormats[i] = int16(v)
+	}
+
+	srv.logger.Debug("bind",
+		zap.String("portal", portalName),
+		zap.String("statement", stmtName),
+		zap.Int("params", int(numParams)),
+	)
+
+	extBackend := conn.ExtendedBackend()
+	if extBackend != nil {
+		err = extBackend.HandleBind(ctx, portalName, stmtName, paramFormats, paramValues, resultFormats)
+		if err != nil {
+			return extendedError(conn, err)
+		}
+	}
+
+	conn.Portals()[portalName] = &Portal{
+		Name:          portalName,
+		Statement:     stmt,
+		ParamFormats:  paramFormats,
+		ParamValues:   paramValues,
+		ResultFormats: resultFormats,
+	}
+
+	return writeBindComplete(conn)
+}
+
+// handleDescribe handles the Describe message ('D') of the extended query protocol.
+// It returns metadata about a prepared statement or portal.
+func (srv *Server) handleDescribe(ctx context.Context, conn SQLConnection) error {
+	prepareType, err := conn.GetPrepareType()
+	if err != nil {
+		return err
+	}
+
+	name, err := conn.GetString()
+	if err != nil {
+		return err
+	}
+
+	srv.logger.Debug("describe",
+		zap.String("type", string(prepareType)),
+		zap.String("name", name),
+	)
+
+	switch prepareType {
+	case buffer.PrepareStatement:
+		return srv.handleDescribeStatement(ctx, conn, name)
+	case buffer.PreparePortal:
+		return srv.handleDescribePortal(ctx, conn, name)
+	default:
+		return extendedError(conn, errors.New("unknown describe type"))
+	}
+}
+
+func (srv *Server) handleDescribeStatement(ctx context.Context, conn SQLConnection, name string) error {
+	stmt, ok := conn.Statements()[name]
+	if !ok {
+		return extendedError(conn, errors.New("prepared statement does not exist: "+name))
+	}
+
+	var paramOIDs []uint32
+	var columns []sqldata.ISQLColumn
+
+	extBackend := conn.ExtendedBackend()
+	if extBackend != nil {
+		var err error
+		paramOIDs, columns, err = extBackend.HandleDescribeStatement(ctx, name, stmt.Query, stmt.ParamOIDs)
+		if err != nil {
+			return extendedError(conn, err)
+		}
+	}
+
+	if paramOIDs == nil {
+		paramOIDs = stmt.ParamOIDs
+	}
+
+	// Send ParameterDescription
+	err := writeParameterDescription(conn, paramOIDs)
+	if err != nil {
+		return err
+	}
+
+	// Send RowDescription or NoData
+	if columns != nil {
+		return writeRowDescriptionFromSQLColumns(ctx, conn, columns)
+	}
+	return writeNoData(conn)
+}
+
+func (srv *Server) handleDescribePortal(ctx context.Context, conn SQLConnection, name string) error {
+	portal, ok := conn.Portals()[name]
+	if !ok {
+		return extendedError(conn, errors.New("portal does not exist: "+name))
+	}
+
+	var columns []sqldata.ISQLColumn
+
+	extBackend := conn.ExtendedBackend()
+	if extBackend != nil {
+		var err error
+		columns, err = extBackend.HandleDescribePortal(ctx, name, portal.Statement.Name, portal.Statement.Query, portal.Statement.ParamOIDs)
+		if err != nil {
+			return extendedError(conn, err)
+		}
+	}
+
+	if columns != nil {
+		return writeRowDescriptionFromSQLColumns(ctx, conn, columns)
+	}
+	return writeNoData(conn)
+}
+
+// handleExecute handles the Execute message ('E') of the extended query protocol.
+// It executes a bound portal and returns result rows.
+func (srv *Server) handleExecute(ctx context.Context, conn SQLConnection) error {
+	portalName, err := conn.GetString()
+	if err != nil {
+		return err
+	}
+
+	maxRowsU32, err := conn.GetUint32()
+	if err != nil {
+		return err
+	}
+	maxRows := int32(maxRowsU32)
+
+	srv.logger.Debug("execute",
+		zap.String("portal", portalName),
+		zap.Int32("maxRows", maxRows),
+	)
+
+	portal, ok := conn.Portals()[portalName]
+	if !ok {
+		return extendedError(conn, errors.New("portal does not exist: "+portalName))
+	}
+
+	extBackend := conn.ExtendedBackend()
+	if extBackend == nil {
+		return commandComplete(conn, "OK")
+	}
+
+	rdr, err := extBackend.HandleExecute(
+		ctx,
+		portalName,
+		portal.Statement.Name,
+		portal.Statement.Query,
+		portal.ParamFormats,
+		portal.ParamValues,
+		portal.ResultFormats,
+		maxRows,
+	)
+	if err != nil {
+		return extendedError(conn, err)
+	}
+
+	if rdr == nil {
+		return commandComplete(conn, "OK")
+	}
+
+	dw := &dataWriter{
+		ctx:    ctx,
+		client: conn,
+	}
+
+	var headersWritten bool
+	for {
+		res, err := rdr.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				notices := conn.GetDebugStr()
+				if res == nil {
+					dw.Complete(notices, "OK")
+					return nil
+				}
+				if !headersWritten {
+					headersWritten = true
+					srv.writeSQLResultHeader(ctx, res, dw)
+				}
+				srv.writeSQLResultRows(ctx, res, dw)
+				dw.Complete(notices, "OK")
+				return nil
+			}
+			return extendedError(conn, err)
+		}
+		if !headersWritten {
+			headersWritten = true
+			// For extended query, we don't send RowDescription here if Describe already sent it.
+			// However, the dataWriter.Define will handle this correctly since columns may already be set.
+			dw.Define(nil)
+		}
+		srv.writeSQLResultRows(ctx, res, dw)
+	}
+}
+
+// handleClose handles the Close message ('C') of the extended query protocol.
+// It closes a prepared statement or portal.
+func (srv *Server) handleClose(ctx context.Context, conn SQLConnection) error {
+	prepareType, err := conn.GetPrepareType()
+	if err != nil {
+		return err
+	}
+
+	name, err := conn.GetString()
+	if err != nil {
+		return err
+	}
+
+	srv.logger.Debug("close",
+		zap.String("type", string(prepareType)),
+		zap.String("name", name),
+	)
+
+	extBackend := conn.ExtendedBackend()
+
+	switch prepareType {
+	case buffer.PrepareStatement:
+		if extBackend != nil {
+			if err := extBackend.HandleCloseStatement(ctx, name); err != nil {
+				return extendedError(conn, err)
+			}
+		}
+		delete(conn.Statements(), name)
+	case buffer.PreparePortal:
+		if extBackend != nil {
+			if err := extBackend.HandleClosePortal(ctx, name); err != nil {
+				return extendedError(conn, err)
+			}
+		}
+		delete(conn.Portals(), name)
+	}
+
+	return writeCloseComplete(conn)
+}
+
+// handleSync handles the Sync message ('S') of the extended query protocol.
+// It signals the end of an extended query cycle and sends ReadyForQuery.
+func (srv *Server) handleSync(ctx context.Context, conn SQLConnection) error {
+	return readyForQuery(conn, types.ServerIdle)
+}
+
+// handleFlush handles the Flush message ('H') of the extended query protocol.
+// It ensures all pending output has been sent to the client.
+// Since our writer sends immediately on End(), this is effectively a no-op.
+func (srv *Server) handleFlush(ctx context.Context, conn SQLConnection) error {
+	return nil
+}
+
+// extendedError sends an ErrorResponse to the client and returns errExtendedQueryError
+// so the command loop enters error state (discards messages until Sync).
+func extendedError(writer buffer.Writer, err error) error {
+	ErrorCode(writer, err)
+	return errExtendedQueryError
+}
+
+// Wire protocol response helpers
+
+func writeParseComplete(writer buffer.Writer) error {
+	writer.Start(types.ServerParseComplete)
+	return writer.End()
+}
+
+func writeBindComplete(writer buffer.Writer) error {
+	writer.Start(types.ServerBindComplete)
+	return writer.End()
+}
+
+func writeCloseComplete(writer buffer.Writer) error {
+	writer.Start(types.ServerCloseComplete)
+	return writer.End()
+}
+
+func writeNoData(writer buffer.Writer) error {
+	writer.Start(types.ServerNoData)
+	return writer.End()
+}
+
+func writeParameterDescription(writer buffer.Writer, paramOIDs []uint32) error {
+	writer.Start(types.ServerParameterDescription)
+	writer.AddInt16(int16(len(paramOIDs)))
+	for _, paramOID := range paramOIDs {
+		writer.AddInt32(int32(paramOID))
+	}
+	return writer.End()
+}
+
+func writeRowDescriptionFromSQLColumns(ctx context.Context, writer buffer.Writer, columns []sqldata.ISQLColumn) error {
+	var colz Columns
+	for _, c := range columns {
+		colz = append(colz, Column{
+			Table:  c.GetTableId(),
+			Name:   c.GetName(),
+			AttrNo: c.GetAttrNum(),
+			Oid:    oid.Oid(c.GetObjectID()),
+			Width:  c.GetWidth(),
+			Format: TextFormat,
+		})
+	}
+	return colz.Define(ctx, writer)
+}

--- a/extended_query_test.go
+++ b/extended_query_test.go
@@ -1,0 +1,437 @@
+package wire
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stackql/psql-wire/internal/mock"
+	"github.com/stackql/psql-wire/internal/types"
+	"github.com/stackql/psql-wire/pkg/sqlbackend"
+	"github.com/stackql/psql-wire/pkg/sqldata"
+)
+
+// --- mock client helpers for extended query protocol ---
+
+// sendParse sends a Parse message: statement name, query, and parameter OIDs.
+func sendParse(t *testing.T, client *mock.Client, stmtName, query string, paramOIDs []uint32) {
+	t.Helper()
+	client.Start(types.ClientParse)
+	client.AddString(stmtName)
+	client.AddNullTerminate()
+	client.AddString(query)
+	client.AddNullTerminate()
+	client.AddInt16(int16(len(paramOIDs)))
+	for _, oid := range paramOIDs {
+		client.AddInt32(int32(oid))
+	}
+	if err := client.End(); err != nil {
+		t.Fatalf("sendParse: %v", err)
+	}
+}
+
+// sendBind sends a Bind message with no parameters and default (text) formats.
+func sendBind(t *testing.T, client *mock.Client, portalName, stmtName string) {
+	t.Helper()
+	client.Start(types.ClientBind)
+	client.AddString(portalName)
+	client.AddNullTerminate()
+	client.AddString(stmtName)
+	client.AddNullTerminate()
+	client.AddInt16(0) // no param format codes
+	client.AddInt16(0) // no param values
+	client.AddInt16(0) // no result format codes
+	if err := client.End(); err != nil {
+		t.Fatalf("sendBind: %v", err)
+	}
+}
+
+// sendDescribeStatement sends a Describe message for a statement.
+func sendDescribeStatement(t *testing.T, client *mock.Client, stmtName string) {
+	t.Helper()
+	client.Start(types.ClientDescribe)
+	client.AddByte('S')
+	client.AddString(stmtName)
+	client.AddNullTerminate()
+	if err := client.End(); err != nil {
+		t.Fatalf("sendDescribeStatement: %v", err)
+	}
+}
+
+// sendDescribePortal sends a Describe message for a portal.
+func sendDescribePortal(t *testing.T, client *mock.Client, portalName string) {
+	t.Helper()
+	client.Start(types.ClientDescribe)
+	client.AddByte('P')
+	client.AddString(portalName)
+	client.AddNullTerminate()
+	if err := client.End(); err != nil {
+		t.Fatalf("sendDescribePortal: %v", err)
+	}
+}
+
+// sendExecute sends an Execute message.
+func sendExecute(t *testing.T, client *mock.Client, portalName string, maxRows int32) {
+	t.Helper()
+	client.Start(types.ClientExecute)
+	client.AddString(portalName)
+	client.AddNullTerminate()
+	client.AddInt32(maxRows)
+	if err := client.End(); err != nil {
+		t.Fatalf("sendExecute: %v", err)
+	}
+}
+
+// sendSync sends a Sync message.
+func sendSync(t *testing.T, client *mock.Client) {
+	t.Helper()
+	client.Start(types.ClientSync)
+	if err := client.End(); err != nil {
+		t.Fatalf("sendSync: %v", err)
+	}
+}
+
+// sendCloseStatement sends a Close message for a statement.
+func sendCloseStatement(t *testing.T, client *mock.Client, stmtName string) {
+	t.Helper()
+	client.Start(types.ClientClose)
+	client.AddByte('S')
+	client.AddString(stmtName)
+	client.AddNullTerminate()
+	if err := client.End(); err != nil {
+		t.Fatalf("sendCloseStatement: %v", err)
+	}
+}
+
+// sendClosePortal sends a Close message for a portal.
+func sendClosePortal(t *testing.T, client *mock.Client, portalName string) {
+	t.Helper()
+	client.Start(types.ClientClose)
+	client.AddByte('P')
+	client.AddString(portalName)
+	client.AddNullTerminate()
+	if err := client.End(); err != nil {
+		t.Fatalf("sendClosePortal: %v", err)
+	}
+}
+
+// expectMsg reads the next message and asserts its type matches.
+func expectMsg(t *testing.T, client *mock.Client, expected types.ServerMessage) {
+	t.Helper()
+	got, _, err := client.ReadTypedMsg()
+	if err != nil {
+		t.Fatalf("expectMsg(%c): read error: %v", expected, err)
+	}
+	if got != expected {
+		t.Fatalf("expected message type %c (%d), got %c (%d)", expected, expected, got, got)
+	}
+}
+
+// expectReadyForQuery reads ReadyForQuery and asserts the transaction status byte.
+func expectReadyForQuery(t *testing.T, client *mock.Client, expectedStatus types.ServerStatus) {
+	t.Helper()
+	expectMsg(t, client, types.ServerReady)
+	bb, err := client.GetBytes(1)
+	if err != nil {
+		t.Fatalf("expectReadyForQuery: %v", err)
+	}
+	if types.ServerStatus(bb[0]) != expectedStatus {
+		t.Fatalf("expected ReadyForQuery status %c, got %c", expectedStatus, bb[0])
+	}
+}
+
+// --- test server helpers ---
+
+// newTestServer creates a server with a simple SQL backend that returns a fixed
+// result for any query.
+func newTestServer(t *testing.T) (*Server, *net.TCPAddr) {
+	t.Helper()
+	cols := []sqldata.ISQLColumn{
+		sqldata.NewSQLColumn(sqldata.NewSQLTable(0, ""), "id", 0, 23, 4, -1, "text"),
+	}
+	rows := []sqldata.ISQLRow{
+		sqldata.NewSQLRow([]interface{}{1}),
+	}
+	result := sqldata.NewSQLResult(cols, 0, 0, rows)
+	stream := sqldata.NewSimpleSQLResultStream(result)
+
+	qcb := func(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
+		return stream, nil
+	}
+
+	factory := sqlbackend.NewSimpleSQLBackendFactory(qcb)
+	server, err := NewServer(SQLBackendFactory(factory))
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := TListenAndServe(t, server)
+	return server, address
+}
+
+// connectAndHandshake dials the server and does a full handshake up to ReadyForQuery.
+func connectAndHandshake(t *testing.T, address *net.TCPAddr) *mock.Client {
+	t.Helper()
+	conn, err := net.Dial("tcp", address.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := mock.NewClient(conn)
+	client.Handshake(t)
+	client.Authenticate(t)
+	client.ReadyForQuery(t)
+	return client
+}
+
+// --- tests ---
+
+func TestExtendedQueryHappyPath(t *testing.T) {
+	t.Parallel()
+	_, address := newTestServer(t)
+	client := connectAndHandshake(t, address)
+
+	// Parse → ParseComplete
+	sendParse(t, client, "", "SELECT 1", nil)
+	expectMsg(t, client, types.ServerParseComplete)
+
+	// Bind → BindComplete
+	sendBind(t, client, "", "")
+	expectMsg(t, client, types.ServerBindComplete)
+
+	// Describe statement → ParameterDescription + NoData
+	sendDescribeStatement(t, client, "")
+	expectMsg(t, client, types.ServerParameterDescription)
+	expectMsg(t, client, types.ServerNoData)
+
+	// Execute → RowDescription + DataRow(s) + CommandComplete (result via default extended backend)
+	sendExecute(t, client, "", 0)
+	// The default backend returns a result with one row
+	expectMsg(t, client, types.ServerRowDescription)
+	expectMsg(t, client, types.ServerDataRow)
+	expectMsg(t, client, types.ServerCommandComplete)
+
+	// Sync → ReadyForQuery(Idle)
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerIdle)
+
+	client.Close(t)
+}
+
+func TestExtendedQueryParseError_DiscardsThroughSync(t *testing.T) {
+	t.Parallel()
+	_, address := newTestServer(t)
+	client := connectAndHandshake(t, address)
+
+	// Bind to a non-existent statement → should trigger error state
+	sendBind(t, client, "", "nonexistent_stmt")
+	expectMsg(t, client, types.ServerErrorResponse)
+
+	// Send more messages — these should all be discarded
+	sendDescribeStatement(t, client, "")
+	sendExecute(t, client, "", 0)
+
+	// Sync should recover and return ReadyForQuery with error status
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerTransactionFailed)
+
+	// After recovery, normal operations should work again.
+	// Send a new Parse → should succeed.
+	sendParse(t, client, "", "SELECT 1", nil)
+	expectMsg(t, client, types.ServerParseComplete)
+
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerIdle)
+
+	client.Close(t)
+}
+
+func TestExtendedQueryExecuteError_DiscardsThroughSync(t *testing.T) {
+	t.Parallel()
+	_, address := newTestServer(t)
+	client := connectAndHandshake(t, address)
+
+	// Execute a non-existent portal → error
+	sendExecute(t, client, "no_such_portal", 0)
+	expectMsg(t, client, types.ServerErrorResponse)
+
+	// Another Execute should be discarded
+	sendExecute(t, client, "no_such_portal", 0)
+
+	// Sync recovers
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerTransactionFailed)
+
+	client.Close(t)
+}
+
+func TestExtendedQueryDescribeError_DiscardsThroughSync(t *testing.T) {
+	t.Parallel()
+	_, address := newTestServer(t)
+	client := connectAndHandshake(t, address)
+
+	// Describe a non-existent statement → error
+	sendDescribeStatement(t, client, "no_such_stmt")
+	expectMsg(t, client, types.ServerErrorResponse)
+
+	// Bind should be discarded
+	sendBind(t, client, "", "")
+
+	// Sync recovers
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerTransactionFailed)
+
+	client.Close(t)
+}
+
+func TestExtendedQueryCloseStatement(t *testing.T) {
+	t.Parallel()
+	_, address := newTestServer(t)
+	client := connectAndHandshake(t, address)
+
+	// Parse a named statement
+	sendParse(t, client, "my_stmt", "SELECT 1", nil)
+	expectMsg(t, client, types.ServerParseComplete)
+
+	// Close statement → CloseComplete
+	sendCloseStatement(t, client, "my_stmt")
+	expectMsg(t, client, types.ServerCloseComplete)
+
+	// Sync
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerIdle)
+
+	// Statement no longer exists → Bind to it should error
+	sendBind(t, client, "", "my_stmt")
+	expectMsg(t, client, types.ServerErrorResponse)
+
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerTransactionFailed)
+
+	client.Close(t)
+}
+
+func TestExtendedQueryClosePortal(t *testing.T) {
+	t.Parallel()
+	_, address := newTestServer(t)
+	client := connectAndHandshake(t, address)
+
+	// Parse + Bind to create a portal
+	sendParse(t, client, "", "SELECT 1", nil)
+	expectMsg(t, client, types.ServerParseComplete)
+
+	sendBind(t, client, "my_portal", "")
+	expectMsg(t, client, types.ServerBindComplete)
+
+	// Close portal → CloseComplete
+	sendClosePortal(t, client, "my_portal")
+	expectMsg(t, client, types.ServerCloseComplete)
+
+	// Sync
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerIdle)
+
+	// Portal no longer exists → Execute should error
+	sendExecute(t, client, "my_portal", 0)
+	expectMsg(t, client, types.ServerErrorResponse)
+
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerTransactionFailed)
+
+	client.Close(t)
+}
+
+func TestExtendedQueryMultipleSyncsAfterError(t *testing.T) {
+	t.Parallel()
+	_, address := newTestServer(t)
+	client := connectAndHandshake(t, address)
+
+	// Trigger error state
+	sendExecute(t, client, "nonexistent", 0)
+	expectMsg(t, client, types.ServerErrorResponse)
+
+	// First Sync → ReadyForQuery(E)
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerTransactionFailed)
+
+	// Second Sync (no error state) → ReadyForQuery(I)
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerIdle)
+
+	client.Close(t)
+}
+
+func TestExtendedQueryNamedStatements(t *testing.T) {
+	t.Parallel()
+	_, address := newTestServer(t)
+	client := connectAndHandshake(t, address)
+
+	// Parse two named statements
+	sendParse(t, client, "stmt_a", "SELECT 1", nil)
+	expectMsg(t, client, types.ServerParseComplete)
+
+	sendParse(t, client, "stmt_b", "SELECT 2", nil)
+	expectMsg(t, client, types.ServerParseComplete)
+
+	// Bind and execute stmt_b
+	sendBind(t, client, "", "stmt_b")
+	expectMsg(t, client, types.ServerBindComplete)
+
+	sendExecute(t, client, "", 0)
+	expectMsg(t, client, types.ServerRowDescription)
+	expectMsg(t, client, types.ServerDataRow)
+	expectMsg(t, client, types.ServerCommandComplete)
+
+	// Bind and execute stmt_a
+	sendBind(t, client, "", "stmt_a")
+	expectMsg(t, client, types.ServerBindComplete)
+
+	sendExecute(t, client, "", 0)
+	expectMsg(t, client, types.ServerRowDescription)
+	expectMsg(t, client, types.ServerDataRow)
+	expectMsg(t, client, types.ServerCommandComplete)
+
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerIdle)
+
+	client.Close(t)
+}
+
+func TestSimpleQueryAfterExtendedQueryError(t *testing.T) {
+	t.Parallel()
+
+	handler := func(ctx context.Context, query string, writer DataWriter) error {
+		return writer.Complete("", "OK")
+	}
+
+	server, err := NewServer(SimpleQuery(handler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := TListenAndServe(t, server)
+	client := connectAndHandshake(t, address)
+
+	// Trigger extended query error (no backend, so Bind to unnamed stmt fails)
+	sendParse(t, client, "", "SELECT 1", nil)
+	expectMsg(t, client, types.ServerParseComplete)
+
+	// Execute unnamed portal which doesn't exist → error
+	sendExecute(t, client, "", 0)
+	expectMsg(t, client, types.ServerErrorResponse)
+
+	// Sync to recover
+	sendSync(t, client)
+	expectReadyForQuery(t, client, types.ServerTransactionFailed)
+
+	// Now a simple query should work fine
+	client.Start(types.ClientSimpleQuery)
+	client.AddString(fmt.Sprintf("SELECT 1"))
+	client.AddNullTerminate()
+	if err := client.End(); err != nil {
+		t.Fatal(err)
+	}
+
+	expectMsg(t, client, types.ServerCommandComplete)
+	expectReadyForQuery(t, client, types.ServerIdle)
+
+	client.Close(t)
+}

--- a/internal/mock/client.go
+++ b/internal/mock/client.go
@@ -134,7 +134,7 @@ func (client *Client) Close(t *testing.T) {
 	t.Log("closing the client!")
 	defer t.Log("client closed")
 
-	client.Start(types.ClientClose)
+	client.Start(types.ClientTerminate)
 	err := client.End()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sqlbackend/extended.go
+++ b/pkg/sqlbackend/extended.go
@@ -1,0 +1,78 @@
+package sqlbackend
+
+import (
+	"context"
+
+	"github.com/stackql/psql-wire/pkg/sqldata"
+)
+
+// IExtendedQueryBackend provides extended query protocol support.
+// Backends that implement this interface (in addition to ISQLBackend)
+// can handle prepared statements, parameter binding, and describe operations.
+//
+// If an ISQLBackend does not implement this interface, the wire server
+// will use a default implementation that delegates Execute to HandleSimpleQuery.
+type IExtendedQueryBackend interface {
+	// HandleParse prepares a SQL statement for later execution.
+	// paramOIDs may contain zeros for unspecified parameter types.
+	HandleParse(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, error)
+
+	// HandleBind binds parameter values to a prepared statement, creating a portal.
+	HandleBind(ctx context.Context, portalName string, stmtName string, paramFormats []int16, paramValues [][]byte, resultFormats []int16) error
+
+	// HandleDescribeStatement returns parameter type OIDs and result column metadata
+	// for a prepared statement.
+	HandleDescribeStatement(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, []sqldata.ISQLColumn, error)
+
+	// HandleDescribePortal returns result column metadata for a bound portal.
+	HandleDescribePortal(ctx context.Context, portalName string, stmtName string, query string, paramOIDs []uint32) ([]sqldata.ISQLColumn, error)
+
+	// HandleExecute executes a bound portal and returns a result stream.
+	// maxRows of 0 means unlimited.
+	HandleExecute(ctx context.Context, portalName string, stmtName string, query string, paramFormats []int16, paramValues [][]byte, resultFormats []int16, maxRows int32) (sqldata.ISQLResultStream, error)
+
+	// HandleCloseStatement closes a prepared statement.
+	HandleCloseStatement(ctx context.Context, stmtName string) error
+
+	// HandleClosePortal closes a portal.
+	HandleClosePortal(ctx context.Context, portalName string) error
+}
+
+// DefaultExtendedQueryBackend provides a default implementation of IExtendedQueryBackend
+// that delegates execution to the simple query path. This is used when the backend
+// does not natively support extended queries.
+type DefaultExtendedQueryBackend struct {
+	backend ISQLBackend
+}
+
+func NewDefaultExtendedQueryBackend(backend ISQLBackend) IExtendedQueryBackend {
+	return &DefaultExtendedQueryBackend{backend: backend}
+}
+
+func (d *DefaultExtendedQueryBackend) HandleParse(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, error) {
+	return paramOIDs, nil
+}
+
+func (d *DefaultExtendedQueryBackend) HandleBind(ctx context.Context, portalName string, stmtName string, paramFormats []int16, paramValues [][]byte, resultFormats []int16) error {
+	return nil
+}
+
+func (d *DefaultExtendedQueryBackend) HandleDescribeStatement(ctx context.Context, stmtName string, query string, paramOIDs []uint32) ([]uint32, []sqldata.ISQLColumn, error) {
+	return paramOIDs, nil, nil
+}
+
+func (d *DefaultExtendedQueryBackend) HandleDescribePortal(ctx context.Context, portalName string, stmtName string, query string, paramOIDs []uint32) ([]sqldata.ISQLColumn, error) {
+	return nil, nil
+}
+
+func (d *DefaultExtendedQueryBackend) HandleExecute(ctx context.Context, portalName string, stmtName string, query string, paramFormats []int16, paramValues [][]byte, resultFormats []int16, maxRows int32) (sqldata.ISQLResultStream, error) {
+	return d.backend.HandleSimpleQuery(ctx, query)
+}
+
+func (d *DefaultExtendedQueryBackend) HandleCloseStatement(ctx context.Context, stmtName string) error {
+	return nil
+}
+
+func (d *DefaultExtendedQueryBackend) HandleClosePortal(ctx context.Context, portalName string) error {
+	return nil
+}

--- a/pkg/sqlbackend/extended_test.go
+++ b/pkg/sqlbackend/extended_test.go
@@ -1,0 +1,191 @@
+package sqlbackend
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stackql/psql-wire/pkg/sqldata"
+)
+
+func TestNewDefaultExtendedQueryBackend(t *testing.T) {
+	cb := func(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
+		return nil, nil
+	}
+	backend := NewSimpleSQLBackend(cb)
+	ext := NewDefaultExtendedQueryBackend(backend)
+	if ext == nil {
+		t.Fatal("expected non-nil extended backend")
+	}
+}
+
+func TestDefaultExtendedQueryBackend_HandleParse(t *testing.T) {
+	tests := []struct {
+		name      string
+		stmtName  string
+		query     string
+		paramOIDs []uint32
+	}{
+		{
+			name:      "no params",
+			stmtName:  "",
+			query:     "SELECT 1",
+			paramOIDs: []uint32{},
+		},
+		{
+			name:      "named statement with params",
+			stmtName:  "my_stmt",
+			query:     "SELECT $1, $2",
+			paramOIDs: []uint32{25, 23},
+		},
+		{
+			name:      "nil params",
+			stmtName:  "",
+			query:     "SELECT 1",
+			paramOIDs: nil,
+		},
+	}
+
+	ext := newTestExtendedBackend(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ext.HandleParse(context.Background(), tt.stmtName, tt.query, tt.paramOIDs)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.paramOIDs) {
+				t.Fatalf("got %d OIDs, want %d", len(got), len(tt.paramOIDs))
+			}
+			for i := range got {
+				if got[i] != tt.paramOIDs[i] {
+					t.Errorf("OID[%d] = %d, want %d", i, got[i], tt.paramOIDs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultExtendedQueryBackend_HandleBind(t *testing.T) {
+	ext := newTestExtendedBackend(t)
+
+	err := ext.HandleBind(
+		context.Background(),
+		"",          // portal
+		"",          // statement
+		[]int16{0},  // param formats (text)
+		[][]byte{[]byte("hello")},
+		[]int16{0},  // result formats (text)
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDefaultExtendedQueryBackend_HandleDescribeStatement(t *testing.T) {
+	ext := newTestExtendedBackend(t)
+
+	paramOIDs := []uint32{25, 23}
+	gotOIDs, gotCols, err := ext.HandleDescribeStatement(
+		context.Background(),
+		"my_stmt",
+		"SELECT $1, $2",
+		paramOIDs,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gotOIDs) != len(paramOIDs) {
+		t.Fatalf("got %d OIDs, want %d", len(gotOIDs), len(paramOIDs))
+	}
+	if gotCols != nil {
+		t.Fatalf("expected nil columns from default backend, got %v", gotCols)
+	}
+}
+
+func TestDefaultExtendedQueryBackend_HandleDescribePortal(t *testing.T) {
+	ext := newTestExtendedBackend(t)
+
+	cols, err := ext.HandleDescribePortal(
+		context.Background(),
+		"",
+		"",
+		"SELECT 1",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cols != nil {
+		t.Fatalf("expected nil columns from default backend, got %v", cols)
+	}
+}
+
+func TestDefaultExtendedQueryBackend_HandleExecute(t *testing.T) {
+	row := sqldata.NewSQLRow([]interface{}{"Alice", 30})
+	col := sqldata.NewSQLColumn(sqldata.NewSQLTable(0, ""), "name", 0, 25, 256, -1, "text")
+	result := sqldata.NewSQLResult([]sqldata.ISQLColumn{col}, 0, 0, []sqldata.ISQLRow{row})
+	stream := sqldata.NewSimpleSQLResultStream(result)
+
+	var receivedQuery string
+	cb := func(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
+		receivedQuery = query
+		return stream, nil
+	}
+
+	backend := NewSimpleSQLBackend(cb)
+	ext := NewDefaultExtendedQueryBackend(backend)
+
+	got, err := ext.HandleExecute(
+		context.Background(),
+		"",                    // portal
+		"",                    // statement
+		"SELECT name FROM t",  // query
+		nil,                   // param formats
+		nil,                   // param values
+		nil,                   // result formats
+		0,                     // max rows (unlimited)
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedQuery != "SELECT name FROM t" {
+		t.Fatalf("got query %q, want %q", receivedQuery, "SELECT name FROM t")
+	}
+
+	res, err := got.Read()
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+	rows := res.GetRows()
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	data := rows[0].GetRowDataNaive()
+	if data[0] != "Alice" {
+		t.Errorf("got %v, want Alice", data[0])
+	}
+}
+
+func TestDefaultExtendedQueryBackend_HandleCloseStatement(t *testing.T) {
+	ext := newTestExtendedBackend(t)
+	if err := ext.HandleCloseStatement(context.Background(), "my_stmt"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDefaultExtendedQueryBackend_HandleClosePortal(t *testing.T) {
+	ext := newTestExtendedBackend(t)
+	if err := ext.HandleClosePortal(context.Background(), "my_portal"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// newTestExtendedBackend creates a DefaultExtendedQueryBackend with a no-op simple backend.
+func newTestExtendedBackend(t *testing.T) IExtendedQueryBackend {
+	t.Helper()
+	cb := func(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
+		return nil, nil
+	}
+	return NewDefaultExtendedQueryBackend(NewSimpleSQLBackend(cb))
+}

--- a/pkg/sqlbackend/pgsqlbackend_test.go
+++ b/pkg/sqlbackend/pgsqlbackend_test.go
@@ -1,0 +1,154 @@
+package sqlbackend
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stackql/psql-wire/pkg/sqldata"
+)
+
+func TestNewSimpleSQLBackend(t *testing.T) {
+	called := false
+	cb := func(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
+		called = true
+		return nil, nil
+	}
+
+	backend := NewSimpleSQLBackend(cb)
+	if backend == nil {
+		t.Fatal("expected non-nil backend")
+	}
+
+	_, _ = backend.HandleSimpleQuery(context.Background(), "SELECT 1")
+	if !called {
+		t.Fatal("expected callback to be called")
+	}
+}
+
+func TestSimpleSQLBackend_HandleSimpleQuery(t *testing.T) {
+	row := sqldata.NewSQLRow([]interface{}{"hello", 42})
+	col := sqldata.NewSQLColumn(sqldata.NewSQLTable(0, ""), "name", 0, 25, 256, -1, "text")
+	result := sqldata.NewSQLResult([]sqldata.ISQLColumn{col}, 0, 0, []sqldata.ISQLRow{row})
+	stream := sqldata.NewSimpleSQLResultStream(result)
+
+	var receivedQuery string
+	cb := func(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
+		receivedQuery = query
+		return stream, nil
+	}
+
+	backend := NewSimpleSQLBackend(cb)
+	got, err := backend.HandleSimpleQuery(context.Background(), "SELECT name FROM users")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedQuery != "SELECT name FROM users" {
+		t.Fatalf("got query %q, want %q", receivedQuery, "SELECT name FROM users")
+	}
+
+	res, err := got.Read()
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+	if len(res.GetRows()) != 1 {
+		t.Fatalf("got %d rows, want 1", len(res.GetRows()))
+	}
+}
+
+func TestSimpleSQLBackend_GetDebugStr(t *testing.T) {
+	cb := func(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
+		return nil, nil
+	}
+	backend := NewSimpleSQLBackend(cb)
+	if got := backend.GetDebugStr(); got != "" {
+		t.Fatalf("got debug string %q, want empty", got)
+	}
+}
+
+func TestSimpleSQLBackend_SplitCompoundQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "single statement",
+			input: "SELECT 1",
+			want:  []string{"SELECT 1"},
+		},
+		{
+			name:  "two statements",
+			input: "SELECT 1;SELECT 2",
+			want:  []string{"SELECT 1", "SELECT 2"},
+		},
+		{
+			name:  "trailing semicolon",
+			input: "SELECT 1;",
+			want:  []string{"SELECT 1", ""},
+		},
+		{
+			name:  "semicolon inside double quotes",
+			input: `SELECT "col;name" FROM t`,
+			want:  []string{`SELECT "col;name" FROM t`},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  []string{""},
+		},
+		{
+			name:  "multiple semicolons",
+			input: "A;B;C",
+			want:  []string{"A", "B", "C"},
+		},
+	}
+
+	cb := func(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
+		return nil, nil
+	}
+	backend := NewSimpleSQLBackend(cb)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := backend.SplitCompoundQuery(tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d parts, want %d: %v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("part[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNewSimpleSQLBackendFactory(t *testing.T) {
+	cb := func(ctx context.Context, query string) (sqldata.ISQLResultStream, error) {
+		return nil, nil
+	}
+
+	factory := NewSimpleSQLBackendFactory(cb)
+	if factory == nil {
+		t.Fatal("expected non-nil factory")
+	}
+
+	backend1, err := factory.NewSQLBackend()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	backend2, err := factory.NewSQLBackend()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// SimpleSQLBackendFactory returns the same instance each time
+	if backend1 != backend2 {
+		t.Fatal("expected factory to return same backend instance")
+	}
+}

--- a/prepared.go
+++ b/prepared.go
@@ -1,0 +1,31 @@
+package wire
+
+// PreparedStatement represents a parsed SQL statement cached per-connection.
+type PreparedStatement struct {
+	Name      string
+	Query     string
+	ParamOIDs []uint32
+}
+
+// Portal represents a bound prepared statement with parameter values, ready for execution.
+type Portal struct {
+	Name          string
+	Statement     *PreparedStatement
+	ParamFormats  []int16
+	ParamValues   [][]byte
+	ResultFormats []int16
+}
+
+// PreparedStatementCache stores prepared statements for a connection.
+type PreparedStatementCache map[string]*PreparedStatement
+
+// PortalCache stores portals for a connection.
+type PortalCache map[string]*Portal
+
+func NewPreparedStatementCache() PreparedStatementCache {
+	return make(PreparedStatementCache)
+}
+
+func NewPortalCache() PortalCache {
+	return make(PortalCache)
+}

--- a/wire_test.go
+++ b/wire_test.go
@@ -179,40 +179,37 @@ func TestServerWritingResult(t *testing.T) {
 		}
 	})
 
-	// NOTE(Jeroen): the jackc/pgx test has been disabled due to a lock of
-	// support for parse, describe, and execute messages. This test could be
-	// enabled again once these message types are supported.
-	// t.Run("jackc/pgx", func(t *testing.T) {
-	// 	ctx := context.Background()
-	// 	connstr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
-	// 	conn, err := pgx.Connect(ctx, connstr)
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
+	t.Run("jackc/pgx", func(t *testing.T) {
+		ctx := context.Background()
+		connstr := fmt.Sprintf("postgres://%s:%d", address.IP, address.Port)
+		conn, err := pgx.Connect(ctx, connstr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 	rows, err := conn.Query(ctx, "SELECT *;")
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
+		rows, err := conn.Query(ctx, "SELECT *;")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 	for rows.Next() {
-	// 		var name string
-	// 		var member bool
-	// 		var age int
+		for rows.Next() {
+			var name string
+			var member bool
+			var age int
 
-	// 		err := rows.Scan(&name, &member, &age)
-	// 		if err != nil {
-	// 			t.Fatal(err)
-	// 		}
+			err := rows.Scan(&name, &member, &age)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// 		t.Logf("scan result: %s, %d, %t", name, age, member)
-	// 	}
+			t.Logf("scan result: %s, %d, %t", name, age, member)
+		}
 
-	// 	err = conn.Close(ctx)
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
-	// })
+		err = conn.Close(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestSQLBackendServerWritingResult(t *testing.T) {


### PR DESCRIPTION
## Summary

- Support for exteneded queries.
- In turn supports prepared statements and myriad client library consumption.
- Unit testing in place.
- Added AOT metadata documentation in `docs/aot_metadata.md`.
- Added migration plan documentation in `docs/stackql_backend_migration.md`.
- Describe idealised extended query implementation.